### PR TITLE
Update footer on 'pages/climate-clarity-score' to latest version

### DIFF
--- a/pages/climate-clarity-score.html
+++ b/pages/climate-clarity-score.html
@@ -236,16 +236,16 @@
         <div class="row gap-y align-items-center">
 
           <div class="col-md-3 text-center text-md-left">
-              <a href="index.html"><img class="logo-dark" src="../assets/img/alectroTurq.png" alt="logo">
+              <a href="/"><img class="logo-dark" src="../assets/img/alectroTurq.png" alt="logo">
           </div>
 
           <div class="col-md-9">
             <div class="nav nav-bold nav-uppercase justify-content-center justify-content-md-end">
-              <a class="nav-link" href="about.html">About Us</a>
-              <a class="nav-link" href="blog">Blog</a>
-              <a class="nav-link" href="policy.html">Policy</a>
+              <a class="nav-link" href="../about.html">About Us</a>
+              <a class="nav-link" href="/blog">Blog</a>
+              <a class="nav-link" href="../policy">Policy</a>
               <a class="nav-link" target="_blank" href="https://vso.alectro.io/companies/6f73c040-8177-4bfe-8b0e-5037d4b08274">ESG Hub <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
-              <a class="nav-link" href="contact.html">Contact</a>
+              <a class="nav-link" href="../contact">Contact</a>
             </div>
           </div>
 

--- a/pages/climate-clarity-score.html
+++ b/pages/climate-clarity-score.html
@@ -230,7 +230,7 @@
     </main>
 
 
-    <!-- Footer -->
+<!-- Footer -->
     <footer class="footer">
       <div class="container">
         <div class="row gap-y align-items-center">
@@ -241,19 +241,21 @@
 
           <div class="col-md-9">
             <div class="nav nav-bold nav-uppercase justify-content-center justify-content-md-end">
-              <a class="nav-link" href="../about.html">About Us</a>
-              <a class="nav-link" href="../blog.html">Blog</a>
-              <a class="nav-link" href="../policy.html">Policy</a>
-              <a class="nav-link" href="../footprint.html">Carbon Impact</a>
-              <a class="nav-link" href="../contact.html">Contact</a>
+              <a class="nav-link" href="about.html">About Us</a>
+              <a class="nav-link" href="blog">Blog</a>
+              <a class="nav-link" href="policy.html">Policy</a>
+              <a class="nav-link" target="_blank" href="https://vso.alectro.io/companies/6f73c040-8177-4bfe-8b0e-5037d4b08274">ESG Hub <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+              <a class="nav-link" href="contact.html">Contact</a>
             </div>
           </div>
 
           <div class="col-12">
+            <iframe src="https://vso.alectro.io/public/queries/climate-clarity-badge?q=6f73c040-8177-4bfe-8b0e-5037d4b08274&responseType=html&theme=light" frameBorder="0" scrolling="no"></iframe>
             <hr class="my-0">
           </div>
 
           <div class="col-md-3 text-center text-md-left">
+
             <small>© 2024 Alectro Limited. All rights reserved.</small>
           </div>
 
@@ -266,9 +268,6 @@
 
         </div>
       </div>
-
-<iframe src="https://dev.alectro.io/public/queries/climate-clarity-badge?q=5c75a4c8-7e4a-445a-8005-4c4a1f45e8f1&responseType=html&theme=light" frameBorder="0" scrolling="no"></iframe>
-
     </footer><!-- /.footer -->
 
     <button class="btn btn-round btn-primary scroll-top"><i class="fa fa-angle-up"></i></button>


### PR DESCRIPTION
# Update Footer w/ Alectro Climate Clarity Badge Integrated

## Brief Description

- Updated footer to match the latest version seen on 'alectro.io'
	-  Contains iframe for climate clarity badge for live updating of score
	-  ESG Hub external link inside footer nav

## Visual Changes

### Before
<img width="1486" alt="image" src="https://github.com/user-attachments/assets/f1303979-cd6f-4141-bea7-59e4726b0f89">

### After
![image](https://github.com/user-attachments/assets/42ff72ae-bcf7-4fc6-a15c-e2c2c46ec333)

## Testing

- Checked over nav links inside footer
- Climate Clarity Badge moved from FB to Alectro
- Tested previously broken link back to homepage via logo